### PR TITLE
docs: fix simple typo, paratheses -> parentheses

### DIFF
--- a/544.output-contest-matches/question.md
+++ b/544.output-contest-matches/question.md
@@ -21,7 +21,7 @@ Output: ((1,4),(2,3))
 Explanation: 
 In the first round, we pair the team 1 and 4, the team 2 and 3 together, as we need to make the strong team and weak team together.
 And we got (1,4),(2,3).
-In the second round, the winners of (1,4) and (2,3) need to play again to generate the final winner, so you need to add the paratheses outside them.
+In the second round, the winners of (1,4) and (2,3) need to play again to generate the final winner, so you need to add the parentheses outside them.
 And we got the final answer ((1,4),(2,3)).
 
 


### PR DESCRIPTION
There is a small typo in 544.output-contest-matches/question.md.

Should read `parentheses` rather than `paratheses`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md